### PR TITLE
Avoid running the upgrade during the CiviCRM System.Check

### DIFF
--- a/chileprovinces.php
+++ b/chileprovinces.php
@@ -496,5 +496,7 @@ function chileprovinces_civicrm_enable() {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
  */
 function chileprovinces_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  chileprovinces_loadcounties();
+  if ($op == 'enqueue') {
+    chileprovinces_loadcounties();
+  }
 }


### PR DESCRIPTION
Otherwise the code is called every 15 minutes by the CiviCRM System.Check (which is part of monitoring).